### PR TITLE
네트워크 수정

### DIFF
--- a/BerryQuest.xcodeproj/project.pbxproj
+++ b/BerryQuest.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		530071572CB67745003C035D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 530071562CB67745003C035D /* Assets.xcassets */; };
 		5300715A2CB67745003C035D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 530071592CB67745003C035D /* Preview Assets.xcassets */; };
 		5337641F2CBD2A7900229540 /* CustomBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5337641E2CBD2A7900229540 /* CustomBottomSheetView.swift */; };
+		534972DC2CCE4F4600D497CD /* PokemonListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534972DB2CCE4F4600D497CD /* PokemonListViewModel.swift */; };
+		534972DF2CCE6E1C00D497CD /* RawDataFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534972DE2CCE6E1C00D497CD /* RawDataFetchable.swift */; };
+		534972E12CCE6E3C00D497CD /* DecodableDataFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534972E02CCE6E3C00D497CD /* DecodableDataFetchable.swift */; };
+		534972E32CCE6E4B00D497CD /* DataNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534972E22CCE6E4B00D497CD /* DataNetworkService.swift */; };
+		534972E52CCE6E6C00D497CD /* DecodableNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534972E42CCE6E6C00D497CD /* DecodableNetworkService.swift */; };
 		534D53F82CBC3A0300930DAC /* PokemonListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534D53F72CBC3A0300930DAC /* PokemonListView.swift */; };
 		534D53FA2CBC3A3A00930DAC /* PokemonContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534D53F92CBC3A3A00930DAC /* PokemonContentView.swift */; };
 		534D53FD2CBC3C3100930DAC /* ContentSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534D53FB2CBC3C3100930DAC /* ContentSize.swift */; };
@@ -29,6 +34,7 @@
 		538E6F212CB67C9200070B32 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E6F202CB67C9200070B32 /* HTTPMethod.swift */; };
 		538E6F232CB67CD600070B32 /* PocketmonRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E6F222CB67CD600070B32 /* PocketmonRequest.swift */; };
 		538E6F282CB6813C00070B32 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E6F272CB6813C00070B32 /* NetworkManager.swift */; };
+		5390F2872CCCC049006103B6 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5390F2862CCCC049006103B6 /* Secrets.xcconfig */; };
 		53B5840C2CB98B3700A1D691 /* pin_red.png in Resources */ = {isa = PBXBuildFile; fileRef = 53B5840B2CB98B3700A1D691 /* pin_red.png */; };
 		53B5840E2CB98B4500A1D691 /* pin_green.png in Resources */ = {isa = PBXBuildFile; fileRef = 53B5840D2CB98B4500A1D691 /* pin_green.png */; };
 		53B584132CB9ACB000A1D691 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B584122CB9ACB000A1D691 /* UIImage+Extension.swift */; };
@@ -36,7 +42,6 @@
 		53B732042CB6C07100D18FAB /* PocketmonInformationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B732032CB6C07100D18FAB /* PocketmonInformationResponse.swift */; };
 		53B7320C2CB6F39700D18FAB /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B7320B2CB6F39700D18FAB /* MapView.swift */; };
 		53B7320E2CB6F3E300D18FAB /* KakaoMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B7320D2CB6F3E300D18FAB /* KakaoMapView.swift */; };
-		53C71AD02CBD543700B7A598 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 53C71ACF2CBD543700B7A598 /* README.md */; };
 		53D0ADDB2CBA5FFC006C8D27 /* RouteSearchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D0ADDA2CBA5FFC006C8D27 /* RouteSearchManager.swift */; };
 		53D87BB12CB9131B00575F05 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D87BB02CB9131B00575F05 /* MapViewModel.swift */; };
 		53FAB47F2CB6FD25005C4D34 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 53FAB47E2CB6FD25005C4D34 /* KakaoMapsSDK-SPM */; };
@@ -49,6 +54,11 @@
 		530071562CB67745003C035D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		530071592CB67745003C035D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5337641E2CBD2A7900229540 /* CustomBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomSheetView.swift; sourceTree = "<group>"; };
+		534972DB2CCE4F4600D497CD /* PokemonListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonListViewModel.swift; sourceTree = "<group>"; };
+		534972DE2CCE6E1C00D497CD /* RawDataFetchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataFetchable.swift; sourceTree = "<group>"; };
+		534972E02CCE6E3C00D497CD /* DecodableDataFetchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableDataFetchable.swift; sourceTree = "<group>"; };
+		534972E22CCE6E4B00D497CD /* DataNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataNetworkService.swift; sourceTree = "<group>"; };
+		534972E42CCE6E6C00D497CD /* DecodableNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableNetworkService.swift; sourceTree = "<group>"; };
 		534D53F72CBC3A0300930DAC /* PokemonListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonListView.swift; sourceTree = "<group>"; };
 		534D53F92CBC3A3A00930DAC /* PokemonContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonContentView.swift; sourceTree = "<group>"; };
 		534D53FB2CBC3C3100930DAC /* ContentSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentSize.swift; sourceTree = "<group>"; };
@@ -66,9 +76,9 @@
 		538E6F1E2CB67C5100070B32 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		538E6F202CB67C9200070B32 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		538E6F222CB67CD600070B32 /* PocketmonRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketmonRequest.swift; sourceTree = "<group>"; };
-		538E6F242CB680B000070B32 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		538E6F252CB680EB00070B32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		538E6F272CB6813C00070B32 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		5390F2862CCCC049006103B6 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		53B5840B2CB98B3700A1D691 /* pin_red.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pin_red.png; sourceTree = "<group>"; };
 		53B5840D2CB98B4500A1D691 /* pin_green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = pin_green.png; sourceTree = "<group>"; };
 		53B584122CB9ACB000A1D691 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
@@ -76,7 +86,6 @@
 		53B732032CB6C07100D18FAB /* PocketmonInformationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketmonInformationResponse.swift; sourceTree = "<group>"; };
 		53B7320B2CB6F39700D18FAB /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		53B7320D2CB6F3E300D18FAB /* KakaoMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMapView.swift; sourceTree = "<group>"; };
-		53C71ACF2CBD543700B7A598 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../Downloads/README.md; sourceTree = "<group>"; };
 		53D0ADDA2CBA5FFC006C8D27 /* RouteSearchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSearchManager.swift; sourceTree = "<group>"; };
 		53D87BB02CB9131B00575F05 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		53FC25382CB840E100FDA7A0 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
@@ -97,9 +106,8 @@
 		530071462CB67743003C035D = {
 			isa = PBXGroup;
 			children = (
-				53C71ACF2CBD543700B7A598 /* README.md */,
-				538E6F242CB680B000070B32 /* Secrets.xcconfig */,
 				538E6F162CB6780900070B32 /* .gitignore */,
+				5390F2862CCCC049006103B6 /* Secrets.xcconfig */,
 				530071512CB67743003C035D /* BerryQuest */,
 				530071502CB67743003C035D /* Products */,
 			);
@@ -139,6 +147,15 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		534972DD2CCE6E0D00D497CD /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				534972DE2CCE6E1C00D497CD /* RawDataFetchable.swift */,
+				534972E02CCE6E3C00D497CD /* DecodableDataFetchable.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		534D53FC2CBC3C3100930DAC /* SystemDesign */ = {
 			isa = PBXGroup;
 			children = (
@@ -151,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				534D54032CBC3E1200930DAC /* PokemonDetailViewModel.swift */,
+				534972DB2CCE4F4600D497CD /* PokemonListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -186,6 +204,7 @@
 		538E6F182CB6787500070B32 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				534972DD2CCE6E0D00D497CD /* Protocol */,
 				538E6F262CB6813400070B32 /* Implement */,
 				538E6F1D2CB67C4B00070B32 /* Enum */,
 				538E6F1A2CB67B4900070B32 /* HTTPRequestBuilder */,
@@ -215,6 +234,8 @@
 			isa = PBXGroup;
 			children = (
 				538E6F272CB6813C00070B32 /* NetworkManager.swift */,
+				534972E22CCE6E4B00D497CD /* DataNetworkService.swift */,
+				534972E42CCE6E6C00D497CD /* DecodableNetworkService.swift */,
 			);
 			path = Implement;
 			sourceTree = "<group>";
@@ -376,10 +397,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5390F2872CCCC049006103B6 /* Secrets.xcconfig in Resources */,
 				5300715A2CB67745003C035D /* Preview Assets.xcassets in Resources */,
 				538E6F172CB6780900070B32 /* .gitignore in Resources */,
 				53B5840E2CB98B4500A1D691 /* pin_green.png in Resources */,
-				53C71AD02CBD543700B7A598 /* README.md in Resources */,
 				537D93F22CBBB0810072B0A7 /* route.png in Resources */,
 				53B5840C2CB98B3700A1D691 /* pin_red.png in Resources */,
 				530071572CB67745003C035D /* Assets.xcassets in Resources */,
@@ -397,12 +418,14 @@
 				53B7320E2CB6F3E300D18FAB /* KakaoMapView.swift in Sources */,
 				53B584132CB9ACB000A1D691 /* UIImage+Extension.swift in Sources */,
 				53B732022CB6C05B00D18FAB /* PocketmonResponse.swift in Sources */,
+				534972E32CCE6E4B00D497CD /* DataNetworkService.swift in Sources */,
 				538923E32CBC395E009C1DB0 /* MapPolylineManager.swift in Sources */,
 				534D53FD2CBC3C3100930DAC /* ContentSize.swift in Sources */,
 				53D0ADDB2CBA5FFC006C8D27 /* RouteSearchManager.swift in Sources */,
 				538923E22CBC395E009C1DB0 /* MapPoiManager.swift in Sources */,
 				538E6F1F2CB67C5100070B32 /* NetworkError.swift in Sources */,
 				53FC25392CB840E100FDA7A0 /* LocationManager.swift in Sources */,
+				534972DC2CCE4F4600D497CD /* PokemonListViewModel.swift in Sources */,
 				535925C12CB93613002BE05F /* PocketmonDomain.swift in Sources */,
 				534D53F82CBC3A0300930DAC /* PokemonListView.swift in Sources */,
 				534D54062CBC3E5500930DAC /* PokemonInformationDomain.swift in Sources */,
@@ -411,14 +434,17 @@
 				53B732042CB6C07100D18FAB /* PocketmonInformationResponse.swift in Sources */,
 				538E6F282CB6813C00070B32 /* NetworkManager.swift in Sources */,
 				530071532CB67743003C035D /* BerryQuestApp.swift in Sources */,
+				534972E52CCE6E6C00D497CD /* DecodableNetworkService.swift in Sources */,
 				534D53FF2CBC3CA400930DAC /* NavigationLazyView.swift in Sources */,
 				53B7320C2CB6F39700D18FAB /* MapView.swift in Sources */,
+				534972E12CCE6E3C00D497CD /* DecodableDataFetchable.swift in Sources */,
 				538E6F212CB67C9200070B32 /* HTTPMethod.swift in Sources */,
 				538E6F1C2CB67B5B00070B32 /* HTTPRequestable.swift in Sources */,
 				534D53FA2CBC3A3A00930DAC /* PokemonContentView.swift in Sources */,
 				5337641F2CBD2A7900229540 /* CustomBottomSheetView.swift in Sources */,
 				53D87BB12CB9131B00575F05 /* MapViewModel.swift in Sources */,
 				534D54042CBC3E1200930DAC /* PokemonDetailViewModel.swift in Sources */,
+				534972DF2CCE6E1C00D497CD /* RawDataFetchable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,7 +572,7 @@
 		};
 		5300715E2CB67745003C035D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 538E6F242CB680B000070B32 /* Secrets.xcconfig */;
+			baseConfigurationReference = 5390F2862CCCC049006103B6 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/BerryQuest/DataModel/DTO/PocketmonResponse.swift
+++ b/BerryQuest/DataModel/DTO/PocketmonResponse.swift
@@ -17,17 +17,13 @@ struct PokemonResponse: Decodable {
 
 extension PokemonResponse {
     
-    func convertToDomain() -> AnyPublisher<PokemonDomain, Error> {
-        return NetworkManager.shared.getData(PokemonRequest.pokemonImage(id: "\(self.id)"))
-            .map { imageData in
-                PokemonDomain(
-                    id: self.id,
-                    name: self.name,
-                    imageData: imageData,
-                    coordinate: self.coordinate.convertToDomain()
-                )
-            }
-            .eraseToAnyPublisher()
+    func convertToDomain() -> PokemonDomain {
+        return PokemonDomain(
+            id: self.id,
+            name: self.name,
+            imageURL: self.imageURL, 
+            coordinate: self.coordinate.convertToDomain()
+        )
     }
     
 }

--- a/BerryQuest/DataModel/DomainModel/PocketmonDomain.swift
+++ b/BerryQuest/DataModel/DomainModel/PocketmonDomain.swift
@@ -12,8 +12,9 @@ import KakaoMapsSDK
 struct PokemonDomain: Decodable {
     let id: Int
     let name: String
-    let imageData: Data
+    let imageURL: String
     let coordinate: Coordinate
+    var image: Data?
 }
 
 struct Coordinate: Decodable {

--- a/BerryQuest/DataModel/DomainModel/PokemonInformationDomain.swift
+++ b/BerryQuest/DataModel/DomainModel/PokemonInformationDomain.swift
@@ -14,4 +14,5 @@ struct PokemonInformationDomain: Decodable {
     let coordinate: Coordinate
     let disease: String
     let berry: String
+    var image: Data?
 }

--- a/BerryQuest/Network/Implement/DataNetworkService.swift
+++ b/BerryQuest/Network/Implement/DataNetworkService.swift
@@ -1,0 +1,33 @@
+//
+//  DataNetworkService.swift
+//  BerryQuest
+//
+//  Created by 김수경 on 10/27/24.
+//
+
+import Foundation
+import Combine
+
+final class DataNetworkService: RawDataFetchable {
+    
+    private let session: URLSession
+    
+    init(session: URLSession = URLSession.shared) {
+        self.session = session
+    }
+
+    func getData(_ request: HTTPRequestable) -> AnyPublisher<Data, Error> {
+        guard let url = request.asURL() else {
+            return Fail(error: NetworkError.invalidURL)
+                .eraseToAnyPublisher()
+        }
+        
+        return session.dataTaskPublisher(for: url)
+            .mapError {
+                NetworkError.unknownError(description: $0.localizedDescription)
+            }
+            .map(\.data)
+            .eraseToAnyPublisher()
+    }
+    
+}

--- a/BerryQuest/Network/Implement/DecodableNetworkService.swift
+++ b/BerryQuest/Network/Implement/DecodableNetworkService.swift
@@ -1,0 +1,35 @@
+//
+//  DecodableNetworkService.swift
+//  BerryQuest
+//
+//  Created by 김수경 on 10/27/24.
+//
+
+import Foundation
+import Combine
+
+final class DecodableNetworkService: DecodableDataFetchable {
+    
+    static let decoder = JSONDecoder()
+    private let session: URLSession
+    
+    init(session: URLSession = URLSession.shared) {
+        self.session = session
+    }
+    
+    func getData<D: Decodable>(_ request: HTTPRequestable, response: D.Type) -> AnyPublisher<D, Error> {
+        guard let url = request.asURL() else {
+            return Fail(error: NetworkError.invalidURL)
+                .eraseToAnyPublisher()
+        }
+        
+        return session.dataTaskPublisher(for: url)
+            .mapError {
+                NetworkError.unknownError(description: $0.localizedDescription)
+            }
+            .map(\.data)
+            .decode(type: D.self, decoder: DecodableNetworkService.decoder)
+            .eraseToAnyPublisher()
+    }
+    
+}

--- a/BerryQuest/Network/Protocol/DecodableDataFetchable.swift
+++ b/BerryQuest/Network/Protocol/DecodableDataFetchable.swift
@@ -1,0 +1,13 @@
+//
+//  DecodableDataFetchable.swift
+//  BerryQuest
+//
+//  Created by 김수경 on 10/27/24.
+//
+
+import Foundation
+import Combine
+
+protocol DecodableDataFetchable {
+    func getData<D: Decodable>(_ request: HTTPRequestable, response: D.Type) -> AnyPublisher<D, Error>
+}

--- a/BerryQuest/Network/Protocol/RawDataFetchable.swift
+++ b/BerryQuest/Network/Protocol/RawDataFetchable.swift
@@ -1,0 +1,13 @@
+//
+//  RawDataFetchable.swift
+//  BerryQuest
+//
+//  Created by 김수경 on 10/27/24.
+//
+
+import Foundation
+import Combine
+
+protocol RawDataFetchable {
+    func getData(_ request: HTTPRequestable) -> AnyPublisher<Data, Error>
+}

--- a/BerryQuest/Utilis/LocationManager.swift
+++ b/BerryQuest/Utilis/LocationManager.swift
@@ -40,26 +40,24 @@ final class LocationManager: NSObject, ObservableObject {
 extension LocationManager: CLLocationManagerDelegate {
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        DispatchQueue.global().async {
-            if CLLocationManager.locationServicesEnabled() {
-                switch manager.authorizationStatus {
-                case .authorizedWhenInUse, .authorizedAlways:
-                    self.updateLocation()
-                case .notDetermined:
-                    self.requestAuthorization()
-                case .restricted, .denied:
-                    break
-                default:
-                    break
-                }
-            }
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            self.updateLocation()
+        case .notDetermined:
+            self.requestAuthorization()
+        case .restricted, .denied:
+            break
+        default:
+            break
         }
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
         
-        self.currentLocation = location.coordinate
+        DispatchQueue.main.async {
+            self.currentLocation = location.coordinate
+        }
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {

--- a/BerryQuest/View/BottomSheet/View/PokemonContentView.swift
+++ b/BerryQuest/View/BottomSheet/View/PokemonContentView.swift
@@ -9,17 +9,30 @@ import SwiftUI
 
 struct PokemonListContentView: View {
     
-    @Binding var pokemon: PokemonDomain
+    @ObservedObject var viewModel: PokemonListViewModel
     
     var body: some View {
         HStack {
-            Image(uiImage: UIImage(data: pokemon.imageData) ?? UIImage(systemName: "star")!)
-                .resizable()
-                .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
-                .padding()
-            Text(pokemon.name)
+            if let image = viewModel.pokemon.image,
+                let pokemonImage = UIImage(data: image) {
+                Image(uiImage: pokemonImage)
+                    .resizable()
+                    .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
+                    .padding()
+            } else {
+                ProgressView()
+                    .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
+                    .padding()
+            }
+            Text(viewModel.pokemon.name)
                 .font(.title2)
         }
         .padding()
+        .task {
+            if viewModel.pokemon.image == nil {
+                viewModel.input.viewOnTask.send(())
+            }
+        }
     }
+    
 }

--- a/BerryQuest/View/BottomSheet/View/PokemonDetailView.swift
+++ b/BerryQuest/View/BottomSheet/View/PokemonDetailView.swift
@@ -17,15 +17,20 @@ struct PokemonDetailView: View {
     
     var body: some View {
         VStack {
-            if let imageData = viewModel.pokemonImage,
-               let pokemon = viewModel.pokemon {
+            if let pokemon = viewModel.pokemon {
                 VStack(alignment: .leading, spacing: 10) {
                     
                     HStack(alignment: .center) {
                         Spacer()
-                        Image(uiImage: UIImage(data: imageData) ?? UIImage(systemName: "star")!)
-                            .resizable()
-                            .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
+                        if let image = viewModel.pokemonImage,
+                           let pokemonImage = UIImage(data: image) {
+                            Image(uiImage: pokemonImage)
+                                .resizable()
+                                .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
+                        } else {
+                            ProgressView()
+                                .frame(width: ContentSize.thumbImage.size.width, height: ContentSize.thumbImage.size.height)
+                        }
                         Spacer()
                     }
                     .padding(.vertical)

--- a/BerryQuest/View/BottomSheet/View/PokemonListView.swift
+++ b/BerryQuest/View/BottomSheet/View/PokemonListView.swift
@@ -18,7 +18,7 @@ struct PokemonListView: View {
                     NavigationLink {
                         NavigationLazyView(PokemonDetailView(id: pokemons[index].id))
                     } label : {
-                        PokemonListContentView(pokemon: $pokemons[index])
+                        PokemonListContentView(viewModel: PokemonListViewModel(pokemon: $pokemons[index]))
                     }
                 }                
             }

--- a/BerryQuest/View/BottomSheet/ViewModel/PokemonDetailViewModel.swift
+++ b/BerryQuest/View/BottomSheet/ViewModel/PokemonDetailViewModel.swift
@@ -10,17 +10,20 @@ import Combine
 
 final class PokemonDetailViewModel: ObservableObject {
     
+    @Published var pokemon: PokemonInformationDomain?
+    @Published var pokemonImage: Data?
+    
+    private let networkManager = PokemonNetworkManager(imageDataNetworkService: DataNetworkService(), decodableNetworkService: DecodableNetworkService())
+    private var pokemonId: Int
+    private var cancellables = Set<AnyCancellable>()
+    
     struct Input {
         let viewOnTask = PassthroughSubject<Void, Never>()
+        
     }
     
     var input = Input()
     
-    private var pokemonId: Int
-    private var cancellables = Set<AnyCancellable>()
-    
-    @Published var pokemon: PokemonInformationDomain?
-    @Published var pokemonImage: Data?
     
     init(pokemonId: Int) {
         self.pokemonId = pokemonId
@@ -36,8 +39,7 @@ final class PokemonDetailViewModel: ObservableObject {
     }
     
     private func getPokemonInformation() {
-        NetworkManager.shared
-            .getData(PokemonRequest.pokemon(id: String(pokemonId)), response: PokemonInformationResponse.self)
+        networkManager.fetchPokemonData(PokemonRequest.pokemon(id: String(pokemonId)), responseType: PokemonInformationResponse.self)
             .receive(on: DispatchQueue.main)
             .sink(
                 receiveCompletion: { completion in
@@ -54,8 +56,7 @@ final class PokemonDetailViewModel: ObservableObject {
     }
     
     private func getPokemonImage() {
-        NetworkManager.shared
-            .getData(PokemonRequest.pokemonImage(id: String(pokemonId)))
+        networkManager.fetchImageData(PokemonRequest.pokemonImage(id: String(pokemonId)))
             .receive(on: DispatchQueue.main)
             .sink(
                 receiveCompletion: { completion in

--- a/BerryQuest/View/BottomSheet/ViewModel/PokemonListViewModel.swift
+++ b/BerryQuest/View/BottomSheet/ViewModel/PokemonListViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  PokemonListViewModel.swift
+//  BerryQuest
+//
+//  Created by 김수경 on 10/27/24.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+final class PokemonListViewModel: ObservableObject {
+    
+    @Binding private(set) var pokemon: PokemonDomain
+    
+    private let networkManager = PokemonNetworkManager(imageDataNetworkService: DataNetworkService(), decodableNetworkService: DecodableNetworkService())
+    private var cancellables = Set<AnyCancellable>()
+    
+    struct Input {
+        let viewOnTask = PassthroughSubject<Void, Never>()
+    }
+    
+    var input = Input()
+    
+    init(pokemon: Binding<PokemonDomain>) {
+        self._pokemon = pokemon
+        setBinding()
+    }
+    
+    private func setBinding() {
+        input.viewOnTask
+            .sink { [weak self] _ in
+                guard let self else { return }
+                
+                self.getPokemonImage()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func getPokemonImage() {
+        networkManager.fetchImageData(PokemonRequest.pokemonImage(id: String(pokemon.id)))
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let failure) = completion {
+                        print(failure)
+                    }
+                }, receiveValue: { [weak self] value in
+                    guard let self else { return }
+                    
+                    self.pokemon.image = value
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+}

--- a/BerryQuest/View/Map/Service/MapPoiManager.swift
+++ b/BerryQuest/View/Map/Service/MapPoiManager.swift
@@ -48,8 +48,11 @@ final class MapPoiManager {
             var poiStyles = [PoiStyle]()
             for pokemon in pokemons {
                 let pokemonBasicIconStyle = PoiIconStyle(symbol: UIImage(named: "pin_green.png"), anchorPoint: CGPoint(x: 0.5, y: 1.0))
-                let pokemonImageIconStyle = PoiIconStyle(symbol: UIImage(data: pokemon.imageData)?.resize(to: CGSize(width: 30, height: 30)), anchorPoint: CGPoint(x: 0.5, y: 1.0))
                 
+                var pokemonImageIconStyle = pokemonBasicIconStyle
+                if let image = pokemon.image {
+                    pokemonImageIconStyle = PoiIconStyle(symbol: UIImage(data: image)?.resize(to: CGSize(width: 30, height: 30)), anchorPoint: CGPoint(x: 0.5, y: 1.0))
+                }
                 let pokemonBasicPerLevelStyle = PerLevelPoiStyle(iconStyle: pokemonBasicIconStyle, level: 0)
                 let pokemonImagePerLevelStyle = PerLevelPoiStyle(iconStyle: pokemonImageIconStyle, level: 12)
                 

--- a/BerryQuest/View/Map/View/KakaoMapView.swift
+++ b/BerryQuest/View/Map/View/KakaoMapView.swift
@@ -45,7 +45,7 @@ struct KakaoMapView: UIViewRepresentable {
     }
     
     static func dismantleUIView(_ uiView: KMViewContainer, coordinator: KakaoMapCoordinator) {
-        coordinator.controller?.resetEngine()
+//        coordinator.controller?.resetEngine()
     }
     
 }


### PR DESCRIPTION
## 주요 내용
- [x] 네트워크 프로토콜화를 통한 SOLID 원칙 준수
  - 기존에 네트워크 통신과 디코딩 기능을 모두 갖고 있던 NetworkManager를 두개의 프로토콜로 분리하여 SRP와 LSP 준수
  - 분리한 프로토콜을 따르는 객체를 외부에서 주입받도록 하여 OCP, LSP, DIP 준수
- [x] Domain 변환시 Image 통신을 하지 않고 필요한 상황에서 네트워크 통신을 수행
  - 기존에는 DTO에서 Domain을 변환할 때 이미지 통신을 해서 Domain이 Data타입을 갖고 있었는데, 이는 이미지가 필요하지 않은 상황에서도 네트워크 통신을 해야하는 리소스 낭비가 발생한다. 
  - 필요한 상황에서 Domain의 id값을 사용하여 이미지 네트워크 통신을 하도록 변경(하지만 지도에서 모든 이미지를 표시해야하기 때문에 MapViewModel에서 이미지 네트워크 통신을 하고 있음)
  - 만약, 지도 view에서 이미지를 표시할 필요가 없는 경우를 대비하여 List에서 화면에 표시될 때 이미지 네트워크 통신을 하도록 하였고, 네트워크 통신 전까지는 ProgressView를 표시하고 있다.
